### PR TITLE
Introduce error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ name = "findomain"
 version = "0.2.8"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "2.33.0", features = ["yaml"] }
 lazy_static = "1.4.0"
 rand = "0.7.2"
 postgres = "0.15.2"
+failure = "0.1"
 
 [target.arm-unknown-linux-gnueabihf.dependencies]
 openssl = { version = "0.10.24", features = ["vendored"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,2 @@
+pub use failure::{Error, ResultExt};
+pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,9 @@ extern crate clap;
 use clap::App;
 
 use findomain::{get_subdomains, read_from_file};
+use findomain::errors::*;
 
-fn main() {
+fn run() -> Result<()> {
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).get_matches();
     if matches.is_present("target") && matches.is_present("output") {
@@ -49,5 +50,17 @@ fn main() {
             let with_ip = "";
             read_from_file(&file, &with_ip, &with_output)
         }
+    } else {
+        Ok(())
+    }
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("Error: {}", err);
+        for cause in err.iter_chain().skip(1) {
+            eprintln!("Because: {}", cause);
+        }
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
This adds some code to handle errors like #16 more gracefully. I've updated some functions but I didn't go through all of them, for example `get_ip` can panic or return an error string instead of an IP address.

The new error handling for #16 looks like this:
```
% cargo build && BIN="$PWD/target/debug/findomain" && (cd /; "$BIN" -ot example.com)
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s

Target ==> example.com

Searching in the CertSpotter API... 🔍
Searching in the Crtsh database... 🔍
Searching in the Virustotal API... 🔍
Searching in the Sublist3r API... 🔍
Searching in the Facebook API... 🔍
Searching in the Spyse API... 🔍
Searching in the Bufferover API... 🔍
Searching in the Threadcrowd API... 🔍
A timeout ⏳ error has occurred while processing the request in the Sublist3r API. Error description: timed out
Error: Can't open file
Because: Permission denied (os error 13)
```